### PR TITLE
Add livereload to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 markdown
 jinja2
+livereload
 python-frontmatter
 pygments
 pymdown-extensions


### PR DESCRIPTION
It's needed to use `serve.py` but it's not included in the `requirements.txt` at the moment.