### PR TITLE
Fixed wg-netns config hierarchy

### DIFF
--- a/srcs/nordvpn-wireguard-namespaces/index.md
+++ b/srcs/nordvpn-wireguard-namespaces/index.md
@@ -94,11 +94,11 @@ At this point you'll need to prepare a configuration file based on the one you g
 {
   "name": "nordvpn",
   "managed": true,
+  "dns-server": ["103.86.96.100"],
   "interfaces": [
     {
       "name": "nordvpn",
       "address": ["10.5.0.2/16"],
-      "dns-server": ["103.86.96.100"],
       "private-key": "YOUR PRIVATE KEY",
       "peers": [
         {


### PR DESCRIPTION
Thanks a lot for writing the article !
This might be a change from a recent version of the wg-netns script but the "dns-server" key in the config should be in the root instead of the "interfaces" list.
Everything else worked great =)